### PR TITLE
Add FakeId to 1.40.4

### DIFF
--- a/core_mods.json
+++ b/core_mods.json
@@ -971,6 +971,12 @@
                 "version": "1.0.0",
                 "downloadLink": "https://github.com/Metalit/MetaCore/releases/download/v1.0.0/MetaCore.qmod",
                 "filename": "MetaCore_V1_0_0.qmod"
+            },
+            {
+                "id": "FakeId",
+                "version": "0.1.5",
+                "downloadLink": "https://github.com/DanTheMan827-BeatSaber/Quest.FakeID/releases/download/v0.1.5/Fake.ID.qmod",
+                "filename": "FakeId_v0_1_5.qmod"
             }
         ]
     }


### PR DESCRIPTION
1.40.4 fails to check the age of the player, so without this mod they will be unable to access certain songs.